### PR TITLE
drop Test::Deep prereq

### DIFF
--- a/t/030_basic.t
+++ b/t/030_basic.t
@@ -12,7 +12,6 @@ use Cwd                    qw[getcwd];
 use File::Spec::Functions  qw[catdir catfile];
 
 use Test::More;
-use Test::Deep;
 
 my $base = catdir(getcwd(), 't', 'data');
 
@@ -58,7 +57,7 @@ foreach my $number ('001'..'012') {
         $parser->parse($buffer);
     }
     $parser->finish;
-    cmp_deeply(\@got, $exp, "$number-content.dat");
+    is_deeply(\@got, $exp, "$number-content.dat");
 }
 
 done_testing();

--- a/t/035_headers.t
+++ b/t/035_headers.t
@@ -5,7 +5,6 @@ use warnings;
 
 use HTTP::MultiPartParser;
 use Test::More;
-use Test::Deep;
 
 sub parse {
     my ($content) = @_;
@@ -49,7 +48,7 @@ foreach my $test (@tests) {
 
     (my $name = $content) =~ s/([^\x21-\x7E])/sprintf '\x%.2X', ord $1/eg;
 
-    cmp_deeply($got_parts, $exp_parts, "parts ($name)");
+    is_deeply($got_parts, $exp_parts, "parts ($name)");
     is($got_error, $exp_error, "error ($name)");
 }
 

--- a/t/040_malformed.t
+++ b/t/040_malformed.t
@@ -4,7 +4,6 @@ use strict;
 use warnings;
 
 use Test::More;
-use Test::Deep;
 use HTTP::MultiPartParser;
 
 sub parse {
@@ -63,7 +62,7 @@ foreach my $test (@tests) {
 
     (my $name = $content) =~ s/([^\x21-\x7E])/sprintf '\x%.2X', ord $1/eg;
 
-    cmp_deeply($got_parts, $exp_parts, "parts ($name)");
+    is_deeply($got_parts, $exp_parts, "parts ($name)");
     is($got_error, $exp_error, "error ($name)");
 }
 


### PR DESCRIPTION
cmp_deeply is trivially replaceable with Test::More::is_deeply, which allows a dependency to be removed.